### PR TITLE
fix: add omitempty tag to ServerCapabilities struct fields

### DIFF
--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -167,17 +167,17 @@ type LoggingSetLevelRequestParams struct {
 // any server can define its own, additional capabilities.
 type ServerCapabilities struct {
 	// Prompts is present if the server offers any prompt templates.
-	Prompts *PromptCapability `json:"prompts,omitzero"`
+	Prompts *PromptCapability `json:"prompts,omitzero,omitempty"`
 	// Resources is present if the server offers any resources to read.
-	Resources *ResourceCapability `json:"resources,omitzero"`
+	Resources *ResourceCapability `json:"resources,omitzero,omitempty"`
 	// Tools is present if the server offers any tools to call.
-	Tools *ToolCapability `json:"tools,omitzero"`
+	Tools *ToolCapability `json:"tools,omitzero,omitempty"`
 	// Experimental contains non-standard capabilities that the server supports.
-	Experimental map[string]any `json:"experimental,omitzero"`
+	Experimental map[string]any `json:"experimental,omitzero,omitempty"`
 	// Logging is present if the server supports sending log messages to the client.
-	Logging *LoggingCapability `json:"logging,omitzero"`
+	Logging *LoggingCapability `json:"logging,omitzero,omitempty"`
 	// Completions is present if the server supports argument autocompletion suggestions.
-	Completions *CompletionsCapability `json:"completions,omitzero"`
+	Completions *CompletionsCapability `json:"completions,omitzero,omitempty"`
 }
 
 // InitializeResult is sent from the server after receiving an initialize request from the client.


### PR DESCRIPTION
First of all, thank you for creating go-mcp! I immediately tried it out.

I created an MCP server using go-mcp and tested it with Claude Desktop and Cursor, but encountered an issue. 
After investigating, I found the following:

## Problem
The `ServerCapabilities` struct fields were missing `omitempty` tags, which resulted in responses containing null values.

## Fix
Added `omitempty` tags to each field.

## Impact
Fields with null values will now be omitted from the response.

**before**
```
{"jsonrpc":"2.0","id":0,"result":{"protocolVersion":"2024-11-05","capabilities":{"prompts":{"listChanged":false},"resources":{"subscribe":true,"listChanged":true},"tools":{"listChanged":false},"experimental":null,"logging":{},"completions":{}},"serverInfo":{"name":"Weather Forecast MCP Server","version":"1.0.0"}}}
```
**after**
```
{"jsonrpc":"2.0","id":0,"result":{"protocolVersion":"2024-11-05","capabilities":{"prompts":{"listChanged":false},"resources":{"subscribe":true,"listChanged":true},"tools":{"listChanged":false},"logging":{},"completions":{}},"serverInfo":{"name":"Weather Forecast MCP Server","version":"1.0.0"}}}
```

After applying this fix, the server started working correctly.